### PR TITLE
auth: also catch end_of_buffer while parsing text input

### DIFF
--- a/src/auth/KeyRing.cc
+++ b/src/auth/KeyRing.cc
@@ -203,6 +203,12 @@ void KeyRing::decode(bufferlist::const_iterator& bl) {
   } catch (buffer::error& err) {
     keys.clear();
     decode_plaintext(start_pos);
+  }catch (buffer::end_of_buffer& err) {
+    keys.clear();
+    decode_plaintext(start_pos);
+  } catch (exception& e){
+    keys.clear();
+    decode_plaintext(start_pos);
   }
 }
 


### PR DESCRIPTION
[On FreeBSD]
in KeyRing::decode() text parsing in only executed if decode throws.
This results in an ABORT signal in bin/ceph when running vstart.sh

Only buffer::error is caught, but reading config text sometimes
lets the buffer_length run into absurd numbers.
Getting out of bounds access in the buffer, generating a trap.

So we need to catch that as well.

However adding buffer::end_of_buffer as exception in another case
does not seem to work, because it is not matched????
So catching all exceptions, and continue to perhaps trap in  decode_plaintext()

fixes:



<!--
Thank you for opening a pull request!  Here are some tips on creating
a well formatted contribution.

Please give your pull request a title like "[component]: [short description]"

This is the format for commit messages:

"""
[component]: [short description]

[A longer multiline description]

Fixes: [ticket URL on tracker.ceph.com, create one if necessary]
Signed-off-by: [Your Name] <[your email]>
"""

The Signed-off-by line is important, and it is your certification that
your contributions satisfy the Developers Certificate or Origin.  For
more detail, see SubmittingPatches.rst.

The component is the short name of a major daemon or subsystem,
something like "mon", "osd", "mds", "rbd, "rgw", etc. For ceph-mgr modules,
give the component as "mgr/<module name>" rather than a path into pybind.

For more examples, simply use "git log" and look at some historical commits.

This was just a quick overview.  More information for contributors is available here:
https://raw.githubusercontent.com/ceph/ceph/master/SubmittingPatches.rst

-->
## Checklist
- [ ] References tracker ticket
- [ ] Updates documentation if necessary
- [ ] Includes tests for new functionality or reproducer for bug

---

<details>
<summary>Show available Jenkins commands</summary>

- `jenkins retest this please`
- `jenkins test signed`
- `jenkins test make check`
- `jenkins test make check arm64`
- `jenkins test submodules`
- `jenkins test dashboard`
- `jenkins test dashboard backend`
- `jenkins test docs`
- `jenkins render docs`

</details>